### PR TITLE
Performance optimisation - Singleton pattern for KeyVaultService

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStore.java
+++ b/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStore.java
@@ -175,6 +175,6 @@ public final class KeyVaultKeyStore extends KeyStoreSpi {
 
     @Override
     public void engineLoad(InputStream stream, char[] password) {
-        vaultService = new KeyVaultService();
+        vaultService = KeyVaultService.getInstance();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultRSASignature.java
+++ b/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultRSASignature.java
@@ -23,7 +23,7 @@ public abstract class KeyVaultRSASignature extends SignatureSpi {
     private final KeyVaultService vaultService;
 
     KeyVaultRSASignature(String algorithm) {
-        this(algorithm, new KeyVaultService());
+        this(algorithm, KeyVaultService.getInstance());
     }
 
     KeyVaultRSASignature(String algorithm, KeyVaultService vaultService) {

--- a/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultService.java
+++ b/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultService.java
@@ -40,6 +40,12 @@ final class KeyVaultService {
 
     private final LoadingCache<String, CertificateBundle> certificateByAliasCache;
 
+    private static final KeyVaultService INSTANCE = new KeyVaultService();
+
+    public static KeyVaultService getInstance() {
+        return INSTANCE;
+    }
+
     // Used by tests to inject the vault client
     KeyVaultService(KeyVaultClient vaultClient, LoadingCache<String, KeyBundle> keyByAliasCache, LoadingCache<String,
         KeyBundle> keyByIdentifierCache, LoadingCache<String, CertificateBundle> certificateByAliasCache) {
@@ -50,7 +56,7 @@ final class KeyVaultService {
         this.certificateByAliasCache = certificateByAliasCache;
     }
 
-    KeyVaultService() {
+    private KeyVaultService() {
         baseUrl = System.getProperty(BASE_URL_PROPERTY);
 
         String clientId = System.getProperty(CLIENT_ID_PROPERTY);


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Right now the provider is initialising a KeyVaultService object on each SIGN request. This adds big  overhead on the request as KeyVaultService initialisation is an expensive operation. 

This PR converts suggests using Singleton pattern for this class. This has been proved to improve performance of signing operation by 50% on average.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
