### PR TITLE
Added implementation of KeyStore.engineContainsAlias

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStore.java
+++ b/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStore.java
@@ -126,11 +126,12 @@ public final class KeyVaultKeyStore extends KeyStoreSpi {
     }
 
     /**
-     * @should throw exception
+     * @should return true when vault contains the certificate
+     * @should return false when vault does not contain the alias
      */
     @Override
     public boolean engineContainsAlias(String alias) {
-        throw new UnsupportedOperationException();
+        return vaultService.getCertificateByAlias(alias) != null;
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStoreTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStoreTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -201,9 +202,23 @@ public class KeyVaultKeyStoreTest {
      * @verifies throw exception
      * @see KeyVaultKeyStore#engineContainsAlias(String)
      */
-    @Test(expected = UnsupportedOperationException.class)
-    public void engineContainsAlias_shouldThrowException() {
-        keyStore.engineContainsAlias(ALIAS);
+    @Test
+    public void engineContainsAlias_shouldReturnTrueWhenVaultContainsTheCertificate() throws Exception {
+        CertificateBundle certBundle = mock(CertificateBundle.class);
+        given(vaultService.getCertificateByAlias(eq(ALIAS))).willReturn(certBundle);
+
+        assertTrue(keyStore.engineContainsAlias(ALIAS));
+    }
+
+    /**
+     * @verifies return false when vault does not contain the alias
+     * @see KeyVaultKeyStore#engineContainsAlias(String)
+     */
+    @Test
+    public void engineContainsAlias_shouldReturnFalseWhenVaultDoesNotContainTheAlias() throws Exception {
+        given(vaultService.getCertificateByAlias(eq(ALIAS))).willReturn(null);
+
+        assertFalse(keyStore.engineContainsAlias(ALIAS));
     }
 
     /**


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Added implementation for `KeyStore.containsAlias`. 

ForgeRock AM would call this method at initial configuration time. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
