### PR TITLE
Fixed implementation of engineContainsAlias in KeyVaultKeyStore

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStore.java
+++ b/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStore.java
@@ -126,7 +126,8 @@ public final class KeyVaultKeyStore extends KeyStoreSpi {
     }
 
     /**
-     * @should return true when vault contains the certificate
+     * @should return true when vault contains  certificate with the required alias
+     * @should return true when vault contains a key with the required alias
      * @should return false when vault does not contain the alias
      */
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStore.java
+++ b/src/main/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStore.java
@@ -131,7 +131,11 @@ public final class KeyVaultKeyStore extends KeyStoreSpi {
      */
     @Override
     public boolean engineContainsAlias(String alias) {
-        return vaultService.getCertificateByAlias(alias) != null;
+        try {
+            return vaultService.getKeyByAlias(alias) != null || vaultService.getCertificateByAlias(alias) != null;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStoreTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStoreTest.java
@@ -203,7 +203,8 @@ public class KeyVaultKeyStoreTest {
      * @see KeyVaultKeyStore#engineContainsAlias(String)
      */
     @Test
-    public void engineContainsAlias_shouldReturnTrueWhenVaultContainsACertificateWithTheRequiredAlias() throws Exception {
+    public void engineContainsAlias_shouldReturnTrueWhenVaultContainsACertificateWithTheRequiredAlias()
+        throws Exception {
         CertificateBundle certBundle = mock(CertificateBundle.class);
         given(vaultService.getCertificateByAlias(eq(ALIAS))).willReturn(certBundle);
 
@@ -215,7 +216,8 @@ public class KeyVaultKeyStoreTest {
      * @see KeyVaultKeyStore#engineContainsAlias(String)
      */
     @Test
-    public void engineContainsAlias_shouldReturnTrueWhenVaultContainsAKeyWithTheRequiredAlias() throws Exception {
+    public void engineContainsAlias_shouldReturnTrueWhenVaultContainsAKeyWithTheRequiredAlias()
+        throws Exception {
         KeyBundle keyBundle = mock(KeyBundle.class);
         given(vaultService.getKeyByAlias(eq(ALIAS))).willReturn(keyBundle);
 

--- a/src/test/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStoreTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/security/keyvault/KeyVaultKeyStoreTest.java
@@ -199,13 +199,25 @@ public class KeyVaultKeyStoreTest {
     }
 
     /**
-     * @verifies throw exception
+     * @verifies return true when vault contains a certificate with the required alias
      * @see KeyVaultKeyStore#engineContainsAlias(String)
      */
     @Test
-    public void engineContainsAlias_shouldReturnTrueWhenVaultContainsTheCertificate() throws Exception {
+    public void engineContainsAlias_shouldReturnTrueWhenVaultContainsACertificateWithTheRequiredAlias() throws Exception {
         CertificateBundle certBundle = mock(CertificateBundle.class);
         given(vaultService.getCertificateByAlias(eq(ALIAS))).willReturn(certBundle);
+
+        assertTrue(keyStore.engineContainsAlias(ALIAS));
+    }
+
+    /**
+     * @verifies return true when vault contains a key with the required alias
+     * @see KeyVaultKeyStore#engineContainsAlias(String)
+     */
+    @Test
+    public void engineContainsAlias_shouldReturnTrueWhenVaultContainsAKeyWithTheRequiredAlias() throws Exception {
+        KeyBundle keyBundle = mock(KeyBundle.class);
+        given(vaultService.getKeyByAlias(eq(ALIAS))).willReturn(keyBundle);
 
         assertTrue(keyStore.engineContainsAlias(ALIAS));
     }
@@ -217,6 +229,7 @@ public class KeyVaultKeyStoreTest {
     @Test
     public void engineContainsAlias_shouldReturnFalseWhenVaultDoesNotContainTheAlias() throws Exception {
         given(vaultService.getCertificateByAlias(eq(ALIAS))).willReturn(null);
+        given(vaultService.getKeyByAlias(eq(ALIAS))).willReturn(null);
 
         assertFalse(keyStore.engineContainsAlias(ALIAS));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
`KeyStore.engineContainsAlias` is currently only looking for certificates with the required alias - this PR adds a look up in the keys as well.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
